### PR TITLE
fix: unhandled promises for sign + verify

### DIFF
--- a/lib/postMessage-handler.ts
+++ b/lib/postMessage-handler.ts
@@ -39,8 +39,6 @@ const onMessageHandler = (webview: MutableRefObject<WebView>, requests: WebLNPro
       break;
     }
     case "makeInvoice": {
-      console.log("handle makeInvoice");
-
       try {
         const response = await requests.makeInvoice(request.data);
         injectResponseToWebView(webview.current, id, JSON.stringify(response));
@@ -50,8 +48,6 @@ const onMessageHandler = (webview: MutableRefObject<WebView>, requests: WebLNPro
       break;
     }
     case "sendPayment": {
-      console.log("handler sendPayment");
-
       try {
         const response = await requests.sendPayment(request.data);
         injectResponseToWebView(webview.current, id, JSON.stringify(response));

--- a/lib/postMessage-handler.ts
+++ b/lib/postMessage-handler.ts
@@ -61,13 +61,21 @@ const onMessageHandler = (webview: MutableRefObject<WebView>, requests: WebLNPro
       break;
     }
     case "signMessage": {
-      const response = await requests.signMessage(request.data);
-      injectResponseToWebView(webview.current, id, JSON.stringify(response));
+      try {
+        const response = await requests.signMessage(request.data);
+        injectResponseToWebView(webview.current, id, JSON.stringify(response));
+      } catch (e) {
+        injectResponseToWebView(webview.current, id, new Error(e.message));
+      }
       break;
     }
     case "verifyMessage": {
-      const response = await requests.verifyMessage(request.data.signature, request.data.message);
-      injectResponseToWebView(webview.current, id, JSON.stringify(response));
+      try {
+        const response = await requests.verifyMessage(request.data.signature, request.data.message);
+        injectResponseToWebView(webview.current, id, JSON.stringify(response));
+      } catch (e) {
+        injectResponseToWebView(webview.current, id, new Error(e.message));
+      }
       break;
     }
 


### PR DESCRIPTION
if an RN app uses this library to implement the signMessage / verifyMessage functions and throw an error, the message handler would not properly catch for those functions and the errors won't make it to the webview

this fixes this behavior so those error messages are properly relayed

also removed some logs just to tidy up